### PR TITLE
Upgrades nokogiri to avoid CVEs

### DIFF
--- a/githubstats.gemspec
+++ b/githubstats.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'basiccache', '~> 1.0.0'
   s.add_runtime_dependency 'curb', '~> 0.9.0'
-  s.add_runtime_dependency 'nokogiri', '~> 1.10.0'
+  s.add_runtime_dependency 'nokogiri', '~> 1.10.8'
 
   s.add_development_dependency 'codecov', '~> 0.1.1'
   s.add_development_dependency 'fuubar', '~> 2.5.0'

--- a/lib/githubstats/version.rb
+++ b/lib/githubstats/version.rb
@@ -3,5 +3,5 @@
 ##
 # Define the version
 module GithubStats
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end


### PR DESCRIPTION
As stated in #38, this upgrade avoids these two vulnerabilities: CVE-2020-7595 and CVE-2019-5477
